### PR TITLE
Update to support beta8, fix image content issue

### DIFF
--- a/app/code/Example/PageBuilderFaq/view/adminhtml/pagebuilder/content_type/faq.xml
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/pagebuilder/content_type/faq.xml
@@ -6,7 +6,7 @@
           preview_component="Example_PageBuilderFaq/js/content-type/faq/preview"
           master_component="Magento_PageBuilder/js/content-type/master-collection"
           form="pagebuilder_faq_form"
-          group="layout"
+          menu_section="layout"
           icon="icon-pagebuilder-faq"
           sortOrder="20"
           translate="label">
@@ -21,7 +21,7 @@
             <appearance name="default"
                         default="true"
                         preview_template="Example_PageBuilderFaq/content-type/faq/default/preview"
-                        render_template="Example_PageBuilderFaq/content-type/faq/default/master"
+                        master_template="Example_PageBuilderFaq/content-type/faq/default/master"
                         reader="Magento_PageBuilder/js/master-format/read/configurable">
                 <elements>
                     <element name="main">
@@ -32,7 +32,7 @@
                         <style name="border_radius" source="border_radius" converter="Magento_PageBuilder/js/converter/style/remove-px"/>
                         <style name="margins" storage_key="margins_and_padding" reader="Magento_PageBuilder/js/property/margins" converter="Magento_PageBuilder/js/converter/style/margins"/>
                         <style name="padding" storage_key="margins_and_padding" reader="Magento_PageBuilder/js/property/paddings" converter="Magento_PageBuilder/js/converter/style/paddings"/>
-                        <attribute name="name" source="data-role"/>
+                        <attribute name="name" source="data-content-type"/>
                         <attribute name="appearance" source="data-appearance"/>
                         <css name="css_classes"/>
                     </element>

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/pagebuilder/content_type/faq_item.xml
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/pagebuilder/content_type/faq_item.xml
@@ -5,11 +5,10 @@
           component="Magento_PageBuilder/js/content-type-collection"
           preview_component="Example_PageBuilderFaq/js/content-type/faq-item/preview"
           form="pagebuilder_faq_item_form"
-          group="layout"
+          menu_section="layout"
           icon="icon-pagebuilder-faq"
           sortOrder="25"
-          translate="label"
-          is_hideable="false">
+          translate="label">
         <parents default_policy="deny">
             <parent name="faq" policy="allow"/>
         </parents>
@@ -18,7 +17,7 @@
             <appearance name="default"
                         default="true"
                         preview_template="Example_PageBuilderFaq/content-type/faq-item/default/preview"
-                        render_template="Example_PageBuilderFaq/content-type/faq-item/default/master"
+                        master_template="Example_PageBuilderFaq/content-type/faq-item/default/master"
                         reader="Magento_PageBuilder/js/master-format/read/configurable">
                 <elements>
                     <element name="main">
@@ -29,7 +28,7 @@
                         <style name="border_radius" source="border_radius" converter="Magento_PageBuilder/js/converter/style/remove-px"/>
                         <style name="margins" storage_key="margins_and_padding" reader="Magento_PageBuilder/js/property/margins" converter="Magento_PageBuilder/js/converter/style/margins"/>
                         <style name="padding" storage_key="margins_and_padding" reader="Magento_PageBuilder/js/property/paddings" converter="Magento_PageBuilder/js/converter/style/paddings"/>
-                        <attribute name="name" source="data-role"/>
+                        <attribute name="name" source="data-content-type"/>
                         <attribute name="appearance" source="data-appearance"/>
                         <css name="css_classes"/>
                     </element>
@@ -45,7 +44,7 @@
                 </elements>
             </appearance>
         </appearances>
-        <is_visible>false</is_visible>
+        <is_system>false</is_system>
         <additional_data>
             <item name="uploaderConfig" xsi:type="array">
                 <item name="isShowImageUploadInstructions" xsi:type="boolean">true</item>

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq-item/preview.js
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq-item/preview.js
@@ -15,6 +15,7 @@ define([
      * @param parent
      * @param config
      * @param stageId
+     * @constructor
      */
     function Preview(parent, config, stageId) {
         PreviewBase.call(this, parent, config, stageId);
@@ -32,25 +33,25 @@ define([
 
         PreviewBase.prototype.bindEvents.call(this);
 
-        events.on(this.config.name + ":" + this.parent.id + ":updateAfter", function () {
-            var dataStore = self.parent.dataStore.get();
+        events.on(this.config.name + ":" + this.contentType.id + ":updateAfter", function () {
+            var dataStore = self.contentType.dataStore.getState();
 
             var files = dataStore[self.config.additional_data.uploaderConfig.dataScope];
             var imageObject = files ? files[0] : {};
 
-            events.trigger("image:" + self.parent.id + ":assignAfter", imageObject);
+            events.trigger("image:" + self.contentType.id + ":assignAfter", imageObject);
         });
 
         events.on(this.config.name + ":mountAfter", function () {
-            var dataStore = self.parent.dataStore.get();
+            var dataStore = self.contentType.dataStore.getState();
 
             var initialImageValue = dataStore[self.config.additional_data.uploaderConfig.dataScope] || "";
 
             self.uploader = new uploader(
-                "imageuploader_" + self.parent.id,
+                "imageuploader_" + self.contentType.id,
                 self.config.additional_data.uploaderConfig,
-                self.parent.id,
-                self.parent.dataStore,
+                self.contentType.id,
+                self.contentType.dataStore,
                 initialImageValue
             );
         });
@@ -70,12 +71,13 @@ define([
         var self = this;
 
         this.element = element;
-        element.id = this.parent.id + "-editor";
+        element.id = this.contentType.id + "-editor";
         wysiwygFactory(
-            this.parent.id, element.id,
+            this.contentType.id,
+            element.id,
             this.config.name,
             this.config.additional_data.wysiwygConfig.wysiwygConfigData,
-            this.parent.dataStore, "answer"
+            this.contentType.dataStore, "answer"
         ).then(function (wysiwyg) {
             self.wysiwyg = wysiwyg;
         });
@@ -89,11 +91,11 @@ define([
 
         this.textarea = element;
 
-        this.textarea.value = this.parent.dataStore.get("answer");
+        this.textarea.value = this.contentType.dataStore.get("answer");
         this.adjustTextareaHeightBasedOnScrollHeight();
 
-        events.on("form:" + this.parent.id + ":saveAfter", function () {
-           self.textarea.value = self.parent.dataStore.get("answer");
+        events.on("form:" + this.contentType.id + ":saveAfter", function () {
+           self.textarea.value = self.contentType.dataStore.get("answer");
 
            self.adjustTextareaHeightBasedOnScrollHeight();
         });
@@ -104,7 +106,7 @@ define([
      */
     Preview.prototype.onTextareaKeyUp = function () {
         this.adjustTextareaHeightBasedOnScrollHeight();
-        this.parent.dataStore.update(this.textarea.value, "answer");
+        this.contentType.dataStore.update(this.textarea.value, "answer");
     };
 
     /**
@@ -131,7 +133,7 @@ define([
     Preview.prototype.adjustTextareaHeightBasedOnScrollHeight = function () {
         this.textarea.style.height = "";
         var scrollHeight = this.textarea.scrollHeight;
-        var minHeight = parseInt($(this.textarea).css("min-height"), 10);
+        var minHeight = parseInt($(this.textarea).css("min-height").toString(), 10);
 
         if (scrollHeight === minHeight) {
             // Leave height at 'auto'

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq-item/wysiwyg/tinymce4/component-initializer.js
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq-item/wysiwyg/tinymce4/component-initializer.js
@@ -1,56 +1,67 @@
 define([
-    "jquery",
-    "mage/adminhtml/wysiwyg/events"
-], function ($, events) {
+    'jquery',
+    'mage/adminhtml/wysiwyg/events'
+], function ($, WysiwygEvents) {
     'use strict';
 
-    function ComponentInitializer () {
-        this.config = null;
-        this.element = null;
+    /**
+     * @constructor
+     */
+    function ComponentInitializer() {
+
     }
 
-    ComponentInitializer.prototype = Object.create({});
-
     /**
-     * Initialize the instance
+     * Initialize the WYSIWYG instance
      *
      * @param wysiwyg
      */
     ComponentInitializer.prototype.initialize = function (wysiwyg) {
-        this.element = (0, $)("#" + wysiwyg.elementId);
-        this.config = wysiwyg.config;
         var tinymce = wysiwyg.getAdapter();
-        tinymce.eventBus.attachEventHandler(events.afterFocus, this.onFocus.bind(this));
-        tinymce.eventBus.attachEventHandler(events.afterBlur, this.onBlur.bind(this));
+
+        this.$element = $("#" + wysiwyg.elementId);
+        this.config = wysiwyg.config;
+
+        tinymce.eventBus.attachEventHandler(WysiwygEvents.afterFocus, this.onFocus.bind(this));
+        tinymce.eventBus.attachEventHandler(WysiwygEvents.afterBlur, this.onBlur.bind(this));
     };
-    
+
     /**
-     * Called when tinymce is focused
+     * Called when TinyMCE is focused
      */
     ComponentInitializer.prototype.onFocus = function () {
         var self = this;
 
         // If there isn't enough room for a left-aligned toolbar, right align it
-        if ((0, $)(window).width() < this.element.offset().left + parseInt(this.config.adapter_config.minToolbarWidth, 10)) {
-            this.element.addClass("_right-aligned-toolbar");
-        } else {
-            this.element.removeClass("_right-aligned-toolbar");
+        if ($(window).width() <
+            this.$element.offset().left + parseInt(this.config.adapter_config.minToolbarWidth, 10)
+        ) {
+            this.$element.addClass("_right-aligned-toolbar");
+        }
+        else {
+            this.$element.removeClass("_right-aligned-toolbar");
         }
 
-        $.each(this.config.adapter_config.parentSelectorsToUnderlay, function (i, selector) {
-            self.element.closest(selector).css("z-index", 100);
-        });
+        $.each(
+            this.config.adapter_config.parentSelectorsToUnderlay,
+            function (i, selector) {
+                self.$element.closest(selector).css("z-index", 100);
+            }
+        );
     };
 
     /**
-     * Called when tinymce is blurred
+     * Called when TinyMCE is blurred
      */
     ComponentInitializer.prototype.onBlur = function () {
         var self = this;
 
-        $.each(this.config.adapter_config.parentSelectorsToUnderlay, function (i, selector) {
-            self.element.closest(selector).css("z-index", "");
-        });
+        $.each(
+            this.config.adapter_config.parentSelectorsToUnderlay,
+            function (i, selector) {
+                self.$element.closest(selector).css("z-index", "");
+            }
+        );
     };
 
     return ComponentInitializer;

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq-item/wysiwyg/tinymce4/config-modifier.js
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq-item/wysiwyg/tinymce4/config-modifier.js
@@ -1,8 +1,12 @@
 define([], function () {
     'use strict';
 
-    function ConfigModifier () {}
+    /**
+     * @constructor
+     */
+    function ConfigModifier () {
 
+    }
     ConfigModifier.prototype = Object.create({});
 
     /**

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq/preview.js
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/web/js/content-type/faq/preview.js
@@ -16,6 +16,7 @@ define([
      * @param parent
      * @param config
      * @param stageId
+     * @constructor
      */
     function Preview(parent, config, stageId) {
         PreviewCollection.call(this, parent, config, stageId);
@@ -48,13 +49,13 @@ define([
         PreviewCollection.prototype.bindEvents.call(this);
 
         events.on("faq:dropAfter", function (args) {
-            if (args.id === self.parent.id && self.parent.children().length === 0) {
+            if (args.id === self.contentType.id && self.contentType.children().length === 0) {
                 self.addFaqItem();
             }
         });
 
         events.on("faq-item:renderAfter", (args) => {
-            if (args.contentType.parent.id === self.parent.id) {
+            if (args.contentType.parentContentType.id === self.contentType.id) {
                 this.initializeAccordionWidget();
             }
         });
@@ -67,14 +68,14 @@ define([
         var self = this;
         createContentType(
             pageBuilderConfig.getContentTypeConfig("faq-item"),
-            this.parent,
-            this.parent.stageId,
+            this.contentType,
+            this.contentType.stageId,
             {
-                question: $t("Question ") + (self.parent.children().length + 1),
+                question: $t("Question ") + (self.contentType.children().length + 1),
                 answer: $t("Edit answer here.")
             }
         ).then(function (container) {
-            self.parent.addChild(container);
+            self.contentType.addChild(container);
         });
     };
 

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq-item/default/master.html
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq-item/default/master.html
@@ -1,8 +1,10 @@
 <li attr="data.main.attributes" ko-style="data.main.style" css="data.main.css">
     <h3 attr="data.question.attributes" ko-style="data.main.style" css="data.main.css" html="data.question.html" data-collapsible="true"></h3>
-    <div attr="data.answer.attributes" ko-style="data.main.style" css="data.main.css" html="data.answer.html" data-content="true"></div>
-    <img if="data.image.attributes().src"
-         attr="data.image.attributes"
-         css="data.image.css"
-         ko-style="data.image.style" />
+    <div data-content="true">
+        <div attr="data.answer.attributes" ko-style="data.main.style" css="data.main.css" html="data.answer.html"></div>
+        <img if="data.image.attributes().src"
+             attr="data.image.attributes"
+             css="data.image.css"
+             ko-style="data.image.style" />
+    </div>
 </li>

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq/default/master.html
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq/default/master.html
@@ -1,3 +1,3 @@
 <ul attr="data.main.attributes" ko-style="data.main.style" css="data.main.css">
-    <render args="renderChildTemplate" />
+    <render args="masterTemplate" />
 </ul>

--- a/app/code/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq/default/preview.html
+++ b/app/code/Example/PageBuilderFaq/view/adminhtml/web/template/content-type/faq/default/preview.html
@@ -1,6 +1,6 @@
 <div class="pagebuilder-content-type pagebuilder-faq children-min-height" attr="data.main.attributes" ko-style="data.main.style" css="data.main.css" event="{ mouseover: onMouseOver, mouseout: onMouseOut }, mouseoverBubble: false">
     <render args="getOptions().template" />
     <div afterRender="afterRender">
-        <render args="previewChildTemplate" />
+        <render args="childTemplate" />
     </div>
 </div>

--- a/app/code/Example/PageBuilderFaq/view/frontend/web/css/source/content-type/faq-item/_import.less
+++ b/app/code/Example/PageBuilderFaq/view/frontend/web/css/source/content-type/faq-item/_import.less
@@ -2,7 +2,7 @@
 //  FAQ item styles
 //  _____________________________________________
 
-[data-role="faq-item"] {
+[data-content-type="faq-item"] {
     border-top: 1px solid #cccccc !important;
     border-right: 1px solid #cccccc !important;
     border-left: 1px solid #cccccc !important;

--- a/app/code/Example/PageBuilderFaq/view/frontend/web/css/source/content-type/faq/_import.less
+++ b/app/code/Example/PageBuilderFaq/view/frontend/web/css/source/content-type/faq/_import.less
@@ -2,7 +2,7 @@
 //  FAQ styles
 //  _____________________________________________
 
-[data-role="faq"] {
+[data-content-type="faq"] {
     border-bottom: 1px solid #ccc !important;
     list-style-type: none;
     position: relative;


### PR DESCRIPTION
- Update code to support latest v1.0.0-beta8, and thus the eventually released 1.0.0
- Resolve issue where image was not within `data-role="content"` causing it to not be hidden when opening / collapsing the sections 